### PR TITLE
Use /usr/bin/env ruby instead of the complete path

### DIFF
--- a/test_pull_requests
+++ b/test_pull_requests
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # Client script for submitting pull requests for testing
 # as well as updating the test results from Jenkins.


### PR DESCRIPTION
This allows the tool to work with vendorized ruby (in `/opt/`) or tools like rbenv or RVM.
