### PR TITLE
Avoid merge commits

### DIFF
--- a/test_pull_requests
+++ b/test_pull_requests
@@ -430,7 +430,7 @@ pushd #{repo}
   git pull #{pull_request['head']['repo']['ssh_url']} #{pull_request['head']['ref']}
   git pull #{pull_request['head']['repo']['ssh_url']} #{pull_request['head']['ref']} --tags
   git checkout #{pull_request['base']['ref']}
-  git merge tpr_#{pull_request['head']['ref']}_#{pull_request['user']['login']}
+  git merge --ff-only tpr_#{pull_request['head']['ref']}_#{pull_request['user']['login']}
 popd
 }
       output = `#{merge_command}`


### PR DESCRIPTION
Avoid merge commits as long as the author of a pull request:

* works on a `feature_branch`

```bash
$ git checkout -b feature_branch
# makes changes, git add, git commit, git push to local branch
```

* has his fork's `master` branch on par with the `master` of the repo he's contributing to:

```bash
$ git checkout master
# Supposedly, git remote add upstream <link-to-original-repo> has been run sometime up to this point
$ git fetch upstream
$ git merge upstream/master
# If everything is up-to-date here, we don't need to rebase
$ git checkout feature_branch
$ git rebase master
$ git push origin feature_branch -f
```

See https://github.com/GoogleCloudPlatform/kubernetes/issues/4251