### PR TITLE
if submodules, ensure they get updated after merge

### DIFF
--- a/test_pull_requests
+++ b/test_pull_requests
@@ -538,6 +538,7 @@ pushd #{repo}
   git pull #{pull_request['head']['repo']['ssh_url']} #{pull_request['head']['ref']} --tags
   git checkout #{pull_request['base']['ref']}
   git merge tpr_#{pull_request['head']['ref']}_#{pull_request['user']['login']}
+  git submodule update --recursive
 popd
 }
       output = `#{merge_command}`


### PR DESCRIPTION
Without this, the submodule remains at master even though the commit
points at something else. Then the sync script syncs a temporary commit
which basically reverts the submodule to master before testing, making
it impossible to test changes in submodules.

git submodule update does nothing if there are no submodules.