### PR TITLE
Updated logic for get_updated_at to be up-to-date and cleaner

### DIFF
--- a/test_pull_requests
+++ b/test_pull_requests
@@ -838,20 +838,10 @@ popd
       end
       commit = get_last_commit(pull_request['number'], pull_request['base']['repo']['name'])
 
-      changed_after_eval = true
-      if commit['sha'] == previous_sha
-        changed_after_eval = false
-      end
-      #GitHub API isn't consistent here
-      updated_at_str = nil
-      if commit.has_key?('commit')
-        updated_at_str = commit['commit']['committer']['date']
-      else
-        updated_at_str = commit['committer']['date']
-      end
+      updated_at = Time.parse(commit['commit']['committer']['date'])
+      changed_after_last_evaluation = commit['sha'] != previous_sha
 
-      updated_at = Time.parse(updated_at_str)
-      [updated_at, changed_after_eval]
+      [updated_at, changed_after_last_evaluation]
     end
 
     def add_coreq(addtl_pull_id, addtl_pull_repo, login, trigger_login, repo_to_pull_request, settings, trigger_updated_at, updated_at, base_pull_id, base_repo, comments)


### PR DESCRIPTION
In GitHub's V3 API, there is no such field commit[comitter][date],
as the commit[comitter] field is metadata about the comitter. The
date that the last commit was created can now always be found at
commit[commit][comitter][date]. The logic for returning the last
modified time is changed to reflect this.

Also, the logic for determining if the pull request has been mod-
ified since the last bot action is simplified.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@danmcp PTAL