### PR TITLE
Implemented failed job explanation logic

### DIFF
--- a/.test_pull_requests.json.sample
+++ b/.test_pull_requests.json.sample
@@ -8,9 +8,9 @@
   "irc_channel": "#myircchannel",
   "bot_github_user": "mybotuser",
   "repo_to_product": {
-     "myrepo1": "MyProduct",
-     "myrepo2": "MyOtherProduct"
-  }
+    "myrepo1": "MyProduct",
+    "myrepo2": "MyOtherProduct"
+  },
   "action_required_prefix": "Action Required:",
   "repo_groups": {
     "myrepo1": "group1",
@@ -21,18 +21,34 @@
       "name": "test",
       "test_prefix": "Test Results:",
       "allow_multiple": true,
-      "branches": { "*": {"jenkins_job_name": "test_pull_requests_stage",
-                              "downstream_job_name": "build_image_stage",
-                              "build_token": "mytoken"},
-                    "master": {"jenkins_job_name": "test_pull_requests",
-                               "downstream_job_name": "build_image",
-                               "build_token": "mytoken"
-                               "addtl_jenkins_params": {"group1": {"param1": "value1",
-                                                                   "param2": "value2"} }
-                              } },
+      "branches": {
+        "*": {
+          "jenkins_job_name": "test_pull_requests_stage",
+          "downstream_job_name": "build_image_stage",
+          "build_token": "mytoken"
+        },
+        "master": {
+          "jenkins_job_name": "test_pull_requests",
+          "downstream_job_name": "build_image",
+          "build_token": "mytoken",
+          "addtl_jenkins_params": {
+            "group1": {
+              "param1": "value1",
+              "param2": "value2"
+            }
+          }
+        }
+      },
       "repo_to_teams": {
-        "myrepo1": ["111111", "222222", "333333"],
-        "myrepo2": ["111111", "444444"]
+        "myrepo1": [
+          "111111",
+          "222222",
+          "333333"
+        ],
+        "myrepo2": [
+          "111111",
+          "444444"
+        ]
       },
       "repo_to_pull_id_param": {
         "myrepo1": "MYREPO1_PULL_ID",
@@ -46,17 +62,28 @@
       "pretest_settings_key": "test_settings",
       "pretest_comment": "[Test]ing while waiting on the merge queue",
       "allow_multiple": false,
-      "branches": { "*": {"jenkins_job_name": "merge_pull_requests_stage",
-                              "downstream_job_name": "build_image_stage",
-                              "image_base_name": "devenv-stage",
-                              "build_token": "mytoken"},
-                    "master": {"jenkins_job_name": "merge_pull_requests",
-                               "downstream_job_name": "build_image",
-                               "image_base_name": "devenv",
-                               "build_token": "mytoken"} },
+      "branches": {
+        "*": {
+          "jenkins_job_name": "merge_pull_requests_stage",
+          "downstream_job_name": "build_image_stage",
+          "image_base_name": "devenv-stage",
+          "build_token": "mytoken"
+        },
+        "master": {
+          "jenkins_job_name": "merge_pull_requests",
+          "downstream_job_name": "build_image",
+          "image_base_name": "devenv",
+          "build_token": "mytoken"
+        }
+      },
       "repo_to_teams": {
-        "myrepo1": ["111111", "222222"],
-        "myrepo2": ["111111"]
+        "myrepo1": [
+          "111111",
+          "222222"
+        ],
+        "myrepo2": [
+          "111111"
+        ]
       },
       "repo_to_pull_id_param": {
         "myrepo1": "MYREPO1_PULL_ID",

--- a/.test_pull_requests.json.sample
+++ b/.test_pull_requests.json.sample
@@ -50,9 +50,21 @@
           "444444"
         ]
       },
+      "repo_to_admin_teams": {
+        "myrepo1": [
+          "111111"
+        ],
+        "myrepo2": [
+          "111111"
+        ]
+      },
       "repo_to_pull_id_param": {
         "myrepo1": "MYREPO1_PULL_ID",
         "myrepo2": "MYREPO2_PULL_ID"
+      },
+      "flake_identification": {
+        "repo": "myrepo1",
+        "label": "kind/test-flake"
       }
     },
     "merge_test_settings": {
@@ -85,9 +97,21 @@
           "111111"
         ]
       },
+      "repo_to_admin_teams": {
+        "myrepo1": [
+          "111111"
+        ],
+        "myrepo2": [
+          "111111"
+        ]
+      },
       "repo_to_pull_id_param": {
         "myrepo1": "MYREPO1_PULL_ID",
         "myrepo2": "MYREPO2_PULL_ID"
+      },
+      "flake_identification": {
+        "repo": "myrepo1",
+        "label": "kind/test-flake"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -9,32 +9,47 @@ Utility for serially testing and merging pull requests in conjunction with Jenki
  * Write some code, fix bugs locally, submit your pull requests
  * Get your changes reviewed
  * If you aren't sure of your changes, perhaps because of a complicated merge, you'll want to force your changes through verification tests before attempting to merge and perhaps before they get reviewed.  You may also want to do this to show the results to the reviewer.
-   * You (or anyone in an authorized GitHub team) can do this by adding the string [test] (case insensitive) to a comment or the title of your pull request.
-   * If you have prereq/coreq pull requests, you can add their urls (Ex: https://github.com/openshift/origin-server/pull/1) to the comments (one per repo supported), and they will be automatically included in the testing.
+   * You (or anyone in an authorized GitHub team) can do this by adding the case insensitive string `[test]` to a comment or the title of your pull request.
+   * If you have prereq/coreq pull requests, you can add their urls (Ex: ​https://github.com/openshift/origin-server/pull/1) to the comments (one per repo supported), and they will be automatically included in the testing.
    * The results of the test will be put in the pull request. If they don't pass, you'll need to fix the issues before continuing
- * Similar to the [test] flag above, you must add the [merge] flag to the title or a comment of the pull request.  This is the only way you should be getting your changes into the master or stage branches.  The merge flag (handles prereqs the same as [test]) builds and installs your changes with the exact source on the target branch that passed the previous tests. This is done serially so your changes are the only changes since the last successful build. After the tests pass your pull request(s) (including prereqs in comments) are merged into master. Note: if you make changes to your pull request(s) after tests start, your merge will fail and the tests will be retried.
+ * Similar to the `[test]` flag above, you must add the `[merge]` flag to the title or a comment of the pull request.  This is the only way you should be getting your changes into the master or stage branches.  The merge flag (handles prereqs the same as `[test]`) builds and installs your changes with the exact source on the target branch that passed the previous tests. This is done serially so your changes are the only changes since the last successful build. After the tests pass your pull request(s) (including prereqs in comments) are merged into master. Note: if you make changes to your pull request(s) after tests start, your merge will fail and the tests will be retried.
 
 ### Permissions
- * [merge] and [test] flags are only listened to for trusted users (in comments or titles) and are only supported for the configured branches.
- * Retries will automatically occur if a pull request is updated after a failure as long as the owner of the pull request is trusted.  So for example, if you tag a pull request with [merge] for a non trusted user, then they add code to the commit. It will fail on merge because they updated after the tests were started and will not retry until another [merge] tag is added/updated by a trusted user.  Trusted users are determined per test group and you can have multiple GitHub teams assigned to the same repo.
+ * `[merge]` and `[test]` flags are only listened to for trusted users (in comments or titles) and are only supported for the configured branches.
+ * Retries will automatically occur if a pull request is updated after a failure as long as the owner of the pull request is trusted.  So for example, if you tag a pull request with `[merge]` for a non trusted user, then they add code to the commit. It will fail on merge because they updated after the tests were started and will not retry until another `[merge]` tag is added/updated by a trusted user.  Trusted users are determined per test group and you can have multiple GitHub teams assigned to the same repo.
 
 
 ## Setup
- * Add test_pull_requests to your Jenkins system and make sure it's executable
- * Add .test_pull_requests.json to $JENKINS_HOME
- * Configure .test_pull_requests.json according to your system.  You can decide whether to support [test] and/or [merge] as well as potentially add other flags for your use cases.
+ * Add `test_pull_requests` to your Jenkins system and make sure it's executable
+ * Add `.test_pull_requests.json` to `$JENKINS_HOME`
+ * Configure `.test_pull_requests.json` according to your system.  You can decide whether to support `[test]` and/or `[merge]` as well as potentially add other flags for your use cases.
  * For each test group you'll then need to configure your Jenkins to have a corresponding set of jobs.  The general requirements are:
    * A downstream job (typically kicked off after the test job completes) that indicates whether there is a larger problem in your system and merges and/or tests can't take place currently
-   * A [test] job should:
-     * Setup an environment based on the current state of master + the pull request(s).  To perform the merge of the pull request you can use: test_pull_requests --local_merge_pull_request $PULL_ID --repo $REPO
-     * Run any desired tests to prove the build and tests will pass if merged
-   * A [merge] job should:
-     * Setup an environment based on the current state of master + the pull request(s).  To perform the merge of the pull request you can use: test_pull_requests --local_merge_pull_request $PULL_ID --repo $REPO
-     * Run any desired tests to prove the build and tests will pass if merged
-     * Verify each tested pull request is still mergeable with: test_pull_requests --test_merge_pull_request $PULL_ID --repo $REPO
-     * Merge each tested pull request with: test_pull_requests --merge_pull_request $PULL_ID --repo $REPO
- * Run test_pull_requests as a Jenkins or cron job.  Note that GitHub is rate limited but typical projects can still run this script every few mins without running out of requests.
+   * A `[test]` job should:
+     * Setup an environment based on the current state of master + the pull request(s).  To perform the merge of the pull request you can use:
+      ```
+      test_pull_requests --local_merge_pull_request $PULL_ID --repo $REPO
+      ```
 
+     * Run any desired tests to prove the build and tests will pass if merged
+   * A `[merge]` job should:
+     * Setup an environment based on the current state of master + the pull request(s).  To perform the merge of the pull request you can use:
+      ```
+      test_pull_requests --local_merge_pull_request $PULL_ID --repo $REPO
+      ```
+
+     * Run any desired tests to prove the build and tests will pass if merged
+     * Verify each tested pull request is still mergeable with:
+      ```
+      test_pull_requests --test_merge_pull_request $PULL_ID --repo $REPO
+      ```
+
+     * Merge each tested pull request with:
+      ```
+      test_pull_requests --merge_pull_request $PULL_ID --repo $REPO
+      ```
+
+ * Run `test_pull_requests` as a Jenkins or `cron` job.  Note that GitHub is rate limited but typical projects can still run this script every few mins without running out of requests.
 
 Copyright
 ----------------------

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Utility for serially testing and merging pull requests in conjunction with Jenki
    * If you have prereq/coreq pull requests, you can add their urls (Ex: ​https://github.com/openshift/origin-server/pull/1) to the comments (one per repo supported), and they will be automatically included in the testing.
    * The results of the test will be put in the pull request. If they don't pass, you'll need to fix the issues before continuing
  * Similar to the `[test]` flag above, you must add the `[merge]` flag to the title or a comment of the pull request.  This is the only way you should be getting your changes into the master or stage branches.  The merge flag (handles prereqs the same as `[test]`) builds and installs your changes with the exact source on the target branch that passed the previous tests. This is done serially so your changes are the only changes since the last successful build. After the tests pass your pull request(s) (including prereqs in comments) are merged into master. Note: if you make changes to your pull request(s) after tests start, your merge will fail and the tests will be retried.
+ * If flake identification is enabled for a flag, failed jobs will require explanation from users. If a pull request has a failed job and no new code has been pushed, someone will have to link to a valid GitHub issue that explains a test flake causing that job to fail. Administrators can over-ride this system by re-triggering the job.
 
 ### Permissions
  * `[merge]` and `[test]` flags are only listened to for trusted users (in comments or titles) and are only supported for the configured branches.
  * Retries will automatically occur if a pull request is updated after a failure as long as the owner of the pull request is trusted.  So for example, if you tag a pull request with `[merge]` for a non trusted user, then they add code to the commit. It will fail on merge because they updated after the tests were started and will not retry until another `[merge]` tag is added/updated by a trusted user.  Trusted users are determined per test group and you can have multiple GitHub teams assigned to the same repo.
+ * Only administrators are allowed to override the flake identification feature. Adminstrators are not guaranteed to be trusted users, or vice versa.
 
 
 ## Setup

--- a/test_pull_requests
+++ b/test_pull_requests
@@ -20,6 +20,8 @@ require 'pp'
 require 'net/https'
 require 'getoptlong'
 require 'time'
+require 'cgi'
+require 'json'
 
 def usage
   puts <<USAGE
@@ -121,6 +123,11 @@ ACTION_NOT_TEAM             = "#{ACTION_PREFIX} Please contact #{Properties['irc
 ACTION_UNSUPPORTED_BRANCH   = "#{ACTION_PREFIX} Only pull request(s) from #{$branches.pretty_inspect.chomp} are handled by the #{Properties['bot_github_user']}"
 NEEDS_REBASE_LABEL          = "needs-rebase"
 
+# flake_denied_prefix returns the prefix to be used for the flake info comment for a particular job
+def flake_denied_prefix(repo, job)
+  "The #{Properties['repo_to_product'][repo]} #{job} job could not be run again for this pull request."
+end
+
 GITHUB_API_BASE_URL = 'https://api.github.com'
 GITHUB_BASE_URL = 'https://github.com'
 
@@ -152,10 +159,51 @@ def submitted_tests_for_branch(branch)
   $submitted_tests[branch] ? $submitted_tests[branch] : $submitted_tests['*']
 end
 
+# We do not expect the groups used to define trusted and administrative
+# members for this repo to change often, so we will 'cache' the group ID
+# to GitHub name and URL for them in a file on disk.
+TEAM_CACHE_LOCATION = File.expand_path("~/.team_cache.json")
+$team_cache = if File.exists? TEAM_CACHE_LOCATION
+  JSON.parse(IO.read(TEAM_CACHE_LOCATION))
+else
+  {}
+end
+
 # Dynamically extend GitHubAPI to add methods that don't
 # require a local git project
 module Hub
   class GitHubAPI
+
+    # team_url_and_name returns the user-friendly URL and name for a GitHub team.
+    # If the team ID is found in the $team_cache, we will simply use it. If it
+    # is not, however, we will need to expend an API request to list all of the
+    # teams we care about and fill in the $team_cache before continuing.
+    def team_url_and_name(team_id)
+      # We want to return our cached data whenever we have it, but we also want
+      # to refresh our cache once in a while, so with a 1% chance we will ignore
+      # data in our cache and re-list anyway.
+      if !$team_cache.has_key?(team_id) || (rand(100) == 1)
+        $stderr.puts "got into the if... key: $team_cache.has_key?(team_id)"
+        res = get "#{GITHUB_API_BASE_URL}/orgs/#{Properties['github_user']}/teams"
+        if res.success?
+          res.data.each do |team_info|
+            # The GitHub team object doesn't list its own URL, but we can construct
+            # it using the 'slug' and the organization name
+            team_url = "#{GITHUB_BASE_URL}/orgs/#{Properties['github_user']}/teams/#{team_info['slug']}"
+            $team_cache[team_info['id']] = { 'url' => team_url, 'name' => team_info['name']}
+          end
+          # If we just filled out the cache, we should write it to disk so
+          # the next test-pull-requests run can save itself the API call
+          IO.write(TEAM_CACHE_LOCATION, JSON::JSON.pretty_generate($team_cache))
+          $stderr.puts "  Wrote a cache of team ID to URL and proper name at #{TEAM_CACHE_LOCATION}"
+        else
+          $stderr.puts res.body
+          res.error!
+        end
+      end
+      [$team_cache[team_id]['url'], $team_cache[team_id]['name']]
+    end
+
     def list_pull_requests(repo, num_tries=3)
       pull_requests = []
       page = 1
@@ -388,10 +436,21 @@ module Hub
       end
     end
 
-    # Verifies the user is part of a valid team
+    # user_trusted? determines if the user is part of a trusted team in the repository
     def user_trusted?(login, repo, settings)
+      user_in_group?(login, repo, settings, 'repo_to_teams')
+    end
+
+    # user_admin? determines if the user is part of a administrative team in the repository
+    def user_admin?(login, repo, settings)
+      user_in_group?(login, repo, settings, 'repo_to_admin_teams')
+    end
+
+    # user_in_group? determines if the user is part of a team in the repository, where
+    # the group of team members is specified by a group identifier
+    def user_in_group?(login, repo, settings, group_identifier)
       trusted = false
-      repo_setting_key = "#{repo}_#{settings['name']}"
+      repo_setting_key = "#{repo}_#{settings['name']}_#{group_identifier}"
       if $permissions[login]
         if $permissions[login][repo_setting_key]
           trusted = $permissions[login][repo_setting_key] ? true : false
@@ -400,7 +459,7 @@ module Hub
         $permissions[login] = {}
       end
       if $permissions[login][repo_setting_key].nil?
-        settings['repo_to_teams'][repo].each do |team|
+        settings[group_identifier][repo].each do |team|
           res = get "#{GITHUB_API_BASE_URL}/teams/#{team}/members/#{login}"
           trusted = res.success?
           break if trusted
@@ -674,14 +733,17 @@ popd
       return comment
     end
 
-    # get_comment_with_prefix returns a comment authored by the bot with the given prefix, if one exists
+    # get_comment_with_prefix returns a comment authored by the bot with the given prefix, if one exists.
+    # In order to ensure that we don't return a comment that starts with a longer prefix that aliases the
+    # prefix we're passed, the regex we use requires a word boundary anchor or line end at the end of the
+    # prefix we're passed.
     def get_comment_with_prefix(issue_id, repo, comment_prefix, comments=nil)
       prefix_comment = nil
 
       comments = comments ? comments : get_comments(issue_id, repo)
 
       comments.each do |comment|
-        if comment['body'] =~ /^#{comment_prefix} / && (comment['user']['login'] == Properties['bot_github_user'])
+        if comment['body'] =~ /^#{Regexp.quote(comment_prefix)}(\b|$)/ && (comment['user']['login'] == Properties['bot_github_user'])
           prefix_comment = comment
           break
         end
@@ -758,8 +820,22 @@ popd
     end
 
     # get_trusted_trigger_time returns the time at which the last trusted user added a trigger,
-    # as best as we can tell. This will not always be able to determime the exact trigger time.
+    # as best as we can tell. This will not always be able to determine the exact trigger time.
     def get_trusted_trigger_time(pull_request, comments, settings)
+      trigger_time_for_user_in_group(pull_request, comments, settings, 'repo_to_teams')
+    end
+
+    # get_admin_trigger_time returns the time at which the last administrative user added a trigger,
+    # as best as we can tell. This will not always be able to determine the exact trigger time.
+    def get_admin_trigger_time(pull_request, comments, settings)
+      trigger_time_for_user_in_group(pull_request, comments, settings, 'repo_to_admin_teams')
+    end
+
+    # trigger_time_for_user_in_group returns the time at which the last trigger was added to the pull
+    # request by a user in the group identified with the group identifier. This function will return
+    # the time of the last trigger as best as we can tell, and will not always be able to determine
+    # the exact trigger time.
+    def trigger_time_for_user_in_group(pull_request, comments, settings, group_identifier)
       login = pull_request['user']['login']
       updated_at, _ = get_updated_at(pull_request, comments, settings)
       repo = pull_request['base']['repo']['name']
@@ -768,8 +844,8 @@ popd
       trigger_time = nil
       trigger_login = nil
       if pull_request['title'] =~ trigger_regex || pull_request['body'] =~ trigger_regex
-        if user_trusted?(login, repo, settings)
-          # Once we determine that the trusted user has a trigger statement in their pull
+        if user_in_group?(login, repo, settings, group_identifier)
+          # Once we determine that the grouped user has a trigger statement in their pull
           # request title or body, we need to determine what time we will claim the
           # trigger was added. We can't use the created_at time, since the user could
           # edit their title or body to add the trigger, and we can't use the updated_at
@@ -786,21 +862,21 @@ popd
 
       # Even if a trigger statement was found in the pull request body or title,
       # a more recent trigger could exist in the comments, and we want to ensure
-      # that we return the most recent trusted trigger time
+      # that we return the most recent trigger time
       comments.each do |comment|
         if comment['body'] =~ trigger_regex
           comment_login = comment['user']['login']
-          if user_trusted?(comment_login, repo, settings)
+          if user_in_group?(comment_login, repo, settings, group_identifier)
             trigger_comment_updated_at = Time.parse(comment['updated_at'])
-            # If we find a trigger phrase from a trusted user in a comment, we will use
+            # If we find a trigger phrase from a grouped user in a comment, we will use
             # the time that their comment was made as the trigger time if and only if
-            # the trusted user posted their trigger phrase after the last commit was
-            # created, ensuring that the trusted user has signed off on all of the
-            # commits to be tested
-            if user_trusted?(login, repo, settings) || trigger_comment_updated_at > updated_at
-              # Furthermore, we only want to update the trusted trigger time if
-              # we have a more recent time from the trusted user's comment than
-              # the time we got by investigating the pull request body and title
+            # the user posted their trigger phrase after the last commit was created,
+            # ensuring that the grouped user has signed off on all of the commits to be
+            # tested
+            if user_in_group?(login, repo, settings, group_identifier) || trigger_comment_updated_at > updated_at
+              # Furthermore, we only want to update the trigger time if we have a more
+              # recent time from the grouped user's comment than the time we got by
+              # investigating the pull request body and title
               if !trigger_time || trigger_comment_updated_at > trigger_time
                 trigger_time = trigger_comment_updated_at
                 trigger_login = comment_login
@@ -933,6 +1009,103 @@ popd
         $stderr.puts "  #{comment}"
         add_comment(base_pull_id, base_repo, comment) unless get_comment_with_value(base_pull_id, base_repo, comment, comments)
       end
+    end
+
+    # has_valid_flake_comment? determines if a valid flake explanation comment exists,
+    # if there exists no valid comment, a human-readable reason why to help users
+    # understand the expected syntax
+    #
+    # A flake comment is valid iff:
+    #  - the comment contains the failed build URL
+    #  - at least one given issue link in the comment:
+    #    - resides in the correct repository
+    #    - points to issues with the correct label
+    def has_valid_flake_comment?(comments, build_url, settings)
+      general_issue_spec = /(https?:\/\/github.com\/.*\/issues\/[0-9]*)/
+      flake_issue_spec = /(https?:\/\/github.com\/#{Regexp.quote(Properties['github_user'])}\/#{Regexp.quote(settings['flake_identification']['repo'])}\/issues\/([0-9]*))/
+
+      valid_comment_exists = false
+      flake_label = settings['flake_identification']['label']
+      flake_repo = settings['flake_identification']['repo']
+      org_repo = %{#{Properties['github_user']}/#{flake_repo}}
+      flake_label_query = CGI.escape("label:#{flake_label}")
+      issue_link = %{https://github.com/#{org_repo}/issues?q=#{flake_label_query}}
+      reason = %{No comment was found that meets the flake identification requirements. A correctly formatted comment should include a link to the failed Jenkins job and at least one link to a GitHub issue in the [`#{org_repo}` repository](#{issue_link}) with the `#{flake_label}` label.}
+
+      comments = sort_comments(comments)
+      comments.each do |comment|
+        comment_matches_syntax = comment['body'] =~ /#{Regexp.quote(build_url)}/ && comment['body'] =~ general_issue_spec
+        # we can't allow the bot to be a valid author, or we would pick up
+        # comments where the bot explains the flake syntax to GitHub users
+        comment_author_valid = comment['user']['login'] != Properties['bot_github_user']
+        if comment_matches_syntax && comment_author_valid
+          # if we find a comment that matches the flake job syntax from someone
+          # trusted, we need to validate the comment's flake issue list
+          bad_issue_links = []
+          comment['body'].scan(general_issue_spec) do |issue|
+            if issue =~ flake_issue_spec
+              issue_url = $1
+              issue_id = $2.to_i
+              if !issue_has_label?(issue_id, flake_repo, flake_label)
+                # the issue does not have the labels necessary, so it is invalid
+                bad_issue_links << issue_url
+              else
+                valid_comment_exists = true
+              end
+            else
+              # we had a GitHub issue link, but it didn't
+              # match the org or repo that we wanted
+              bad_issue_links << issue
+            end
+          end
+
+          if valid_comment_exists
+            break
+          else
+            # no valid issue links mean that the comment is invalid
+            reason = %{A [comment](#{comment["html_url"]}) was found that referenced the correct Jenkins job URL, but no listed issue links were valid. Ensure at least one linked issue is in the [`#{org_repo}` repository](#{issue_link}) and has the `#{flake_label}` label. Invalid links are:
+ - #{bad_issue_links.join("\n - ")}}
+          end
+        end
+      end
+
+      [valid_comment_exists, reason]
+    end
+
+    # issue_has_label determines if the issue at the
+    # repo and issue ID has a label with the given name
+    def issue_has_label?(issue_id, repo, label)
+      get_labels(issue_id, repo).each do |label|
+        if label["name"] == label
+          return true
+        end
+      end
+      return false
+    end
+
+    # format_teams builds a list of links to team rosters from a list of team IDs
+    def format_teams(team_ids)
+      links = []
+      team_ids.each do |id|
+        url, name = team_url_and_name(id)
+        links << "[#{name}](#{url})"
+      end
+      if links.length == 1
+        %{the #{links[0]} group}
+      else
+        %{the following groups: #{links.join(", ")}}
+      end
+    end
+
+    # format_flake_comment builds a comment explaining why a re-build could not be triggered
+    def format_flake_comment(repo, job, reason, team_ids)
+      %{#{flake_denied_prefix(repo, job)}
+In order for @#{Properties['bot_github_user']} to run the #{Properties['repo_to_product'][repo]} #{job} job again, one of the following actions is necessary:
+ - The proposed patch in this pull request needs to be updated to remove failure conditions that the previous patch introduced
+ - The job needs to be triggered again by a member of #{format_teams(team_ids)}
+ - This pull request page needs to be updated with a comment linking the failure to test or infrastructure flake issues
+
+#{reason}}
     end
 
     #
@@ -1097,6 +1270,60 @@ popd
             updated_comment = "#{settings['test_prefix']} #{result} (#{build_url})"
             updated_comment += extended_tests if extended_tests
             status = result == 'SUCCESS' ? 'success' : 'failure'
+          end
+        when /^#{settings['test_prefix']} FAILURE \(([^\)]*)\)?/
+          # In this case, are in the post-test result state, and the tests have failed
+          #
+          # The two states that we can transition to from here are:
+          #  - loop back into this state if:
+          #      - flake enforcement is configured and
+          #      - there is no comment linking a valid flake issue to the last failed
+          #        job and
+          #      - the is no administrative trigger, overriding the check and
+          #      - the base branch of the pull request has not been updated from the
+          #        version used to run the tests previously
+          #  - into the testing state if either:
+          #      - flake enforcement is not configured, or
+          #      - a contributor has linked the failure to a flake issue, or
+          #      - an administrator has overriden the check, or
+          #      - new code has been pushed to the branch since the last time this bot
+          #        evaluated the pull request
+
+          if !settings['flake_identification']
+            # If no flake configuration exists, it's
+            # ok to re-submit the job whenever a new
+            # trigger is added to the pull request
+            resubmit_test_job = true
+            break
+          end
+
+          # We can capture the URL of the failed build from the regex match
+          build_url=$1
+          $stderr.puts "  Determining if flakes have been identified for failed job: #{build_url}"
+
+          admin_trigger_updated_at, _ = get_admin_trigger_time(req, comments, settings)
+          explanatory_comment_valid, reason = has_valid_flake_comment?(comments, build_url, settings)
+
+          # If we can find an explanatory comment with a valid flake issue in it,
+          # or we find an admin override comment, or the pull request has had new
+          # code added to it since the last evaluation, we know that we are good
+          # to resubmit the pull request for testing
+          if explanatory_comment_valid || (admin_trigger_updated_at && admin_trigger_updated_at > updated_at) || changed_after_eval
+            resubmit_test_job = true
+            delete_comment_with_prefix(id, base_repo, flake_denied_prefix(base_repo, settings['name']), comments)
+          elsif trigger_updated_at && trigger_updated_at > evaluated_time
+            # If someone's tried to trigger a re-test, but we can't re-test right
+            # now, we should leave a helpful message explaining why. If we have
+            # previously warned the user about why we couldn't re-test, we should
+            # only update the pull request with a new set of reasons if the trigger
+            # is newer than our last comment
+            previous_warning = get_comment_with_prefix(id, base_repo, flake_denied_prefix(base_repo, settings['name']), comments)
+            if !previous_warning || (previous_warning && trigger_updated_at > Time.parse(previous_warning['updated_at']))
+              recreate_comment_with_prefix(id, base_repo,
+                flake_denied_prefix(base_repo, settings['name']),
+                format_flake_comment(base_repo, settings['name'], reason, settings['repo_to_admin_teams'][base_repo]),
+                comments)
+            end
           end
         else
           # In this case, we're in one of three states:
@@ -1629,6 +1856,7 @@ popd
   end
 end
 
+
 #
 #
 # The main program script
@@ -1659,3 +1887,4 @@ else
   @api_client.process_pull_requests(merge_pretest_success)
   $stderr.puts "\nDone\n"
 end
+


### PR DESCRIPTION
```
In order to ensure that flaky tests cannot be easily
ignored by GitHub contributors that have the power
to re-trigger Jenkins jobs, this new logic forbids a
job from being re-triggered unless:
 - new code is pushed to update the pull request's
   base branch from the version we used to run the
   failed tests
 - a trusted user posts a comment linking together
   the failed job's URL and the URL of valid GitHub
   issues with labels identifiying them as test
   flakes
 - an administrator re-triggers the job, which will
   override any flake identification logic

If no flake identification configuration is done in
the JSON properties file, the legacy behavior is
unchaged and the job will be re-triggered always.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>
```

@danmcp PTAL first-pass, tests coming