### PR TITLE
Treat failed label queries as successful in flake identification

### DIFF
--- a/test_pull_requests
+++ b/test_pull_requests
@@ -1102,6 +1102,11 @@ popd
         end
       end
       return false
+    rescue => e
+      # Something went wrong but as far as we are
+      # concerned, this issue does not have the label
+      $stderr.puts "      [e.class] #{e.message}"
+      return false
     end
 
     # format_teams builds a list of links to team rosters from a list of team IDs


### PR DESCRIPTION
When a query to determine the labels on a potential flake issue link
fails due to some HTTP error such as a 403 (someone linked a non-
existent issue, rate limit, etc) or 404, we should interpret this as
a link to an invalid issue and not accept the comment as a valid
flake comment.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/openshift/test-pull-requests/issues/40
@danmcp 