### PR TITLE
Make extended prefix configurable

### DIFF
--- a/test_pull_requests
+++ b/test_pull_requests
@@ -1229,7 +1229,7 @@ popd
 
     def get_extended_tests(pull_request, comments, branch, settings)
       extended_tests = []
-      if settings['allow_multiple'] && branch_settings(branch, settings)['extended_tests_param']
+      if branch_settings(branch, settings)['extended_tests_param']
         extended_prefix = settings['extended_prefix'] || 'extended'
         extended_regex = /\[#{extended_prefix} *:( *[^,\[\]]+ *(, *[^,\[\]]+ *)*)\]/i
         if pull_request['title'] =~ extended_regex

--- a/test_pull_requests
+++ b/test_pull_requests
@@ -1230,7 +1230,8 @@ popd
     def get_extended_tests(pull_request, comments, branch, settings)
       extended_tests = []
       if settings['allow_multiple'] && branch_settings(branch, settings)['extended_tests_param']
-        extended_regex = /\[extended *:( *[^,\[\]]+ *(, *[^,\[\]]+ *)*)\]/i
+        extended_prefix = settings['extended_prefix'] || 'extended'
+        extended_regex = /\[#{extended_prefix} *:( *[^,\[\]]+ *(, *[^,\[\]]+ *)*)\]/i
         if pull_request['title'] =~ extended_regex
           extended_tests += $1.split(',')
         end


### PR DESCRIPTION
When we want to use the extended configuration for a trigger to provide
information other than which extended tests to run, we need to use a
different prefix for the comment for better UX. For instance, to provide
severity we will be using:

    [merge][severity:bug]
    [merge][severity:blocker]

These statements would make no sense if the user had to provide the
current `[extended:blocker]` type of comment.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@dobbymoodge PTAL