### PR TITLE
Don't use regex when manipulating config file path

### DIFF
--- a/merge_queue_overview
+++ b/merge_queue_overview
@@ -59,7 +59,7 @@ else
 end
 
 PROPERTIES_LOCATION = config['merge_queue_properties_location'] || DEFAULT_MERGE_QUEUE_PROPERTIES_LOCATION
-MERGE_QUEUE_RECORD_FILENAME = PROPERTIES_LOCATION[/[^\w]+\.(.+\.json)/, 1]
+MERGE_QUEUE_RECORD_FILENAME = File.split(PROPERTIES_LOCATION).last.gsub(/^\./, '')
 MERGE_QUEUE_RECORD = File.expand_path(merge_queue_records || "~/merge_queue_records/#{MERGE_QUEUE_RECORD_FILENAME}")
 
 def write_merge_queue_overview(queue_name, config, queue_records, erb)

--- a/test_pull_requests
+++ b/test_pull_requests
@@ -97,7 +97,7 @@ else
   exit 255
 end
 
-MERGE_QUEUE_RECORD_FILENAME = PROPERTIES_LOCATION[/[^\w]+\.(.+\.json)/, 1]
+MERGE_QUEUE_RECORD_FILENAME = File.split(PROPERTIES_LOCATION).last.gsub(/^\./, '') 
 MERGE_QUEUE_RECORD = File.expand_path("~/merge_queue_records/#{MERGE_QUEUE_RECORD_FILENAME}")
 
 # Branches and repos must be supported for all settings


### PR DESCRIPTION
The intent of the code in question was to grab the basename of the
config path and strip the leading dot, if there was one. By using Ruby
utilities instead of regex we can make this intent more clear and more
robust.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @dobbymoodge 