### PR TITLE
add SCL Ruby wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Utility for serially testing and merging pull requests in conjunction with Jenki
 
 ## Setup
  * Add `test_pull_requests` to your Jenkins system and make sure it's executable
+ * Add `test_pull_requests_ruby_wrapper.sh` to your Jenkins system and make sure it's executable and in the Jenkins user's `$PATH`
+   * If you're running RHEL, follow the instructions in the [Additional considerations for RHEL](#additional-considerations-for-rhel) now.
  * Add `.test_pull_requests.json` to `$JENKINS_HOME`
  * Configure `.test_pull_requests.json` according to your system.  You can decide whether to support `[test]` and/or `[merge]` as well as potentially add other flags for your use cases.
  * For each test group you'll then need to configure your Jenkins to have a corresponding set of jobs.  The general requirements are:
@@ -59,18 +61,9 @@ Utility for serially testing and merging pull requests in conjunction with Jenki
 
 ### Additional considerations for RHEL
  * Your version of RHEL might not have a recent Ruby by default. To work around this, you can:
-   * enable the Software Collections (SCL) repos and install `scl-utils`, and the Ruby version of your choice, e.g. `rh-ruby23`, `rh-ruby23-rubygems`, and `rh-ruby23-rubygem-bundler`
-   * run `test_pull_requests` like:
-   ```bash
-   echo "test_pull_requests --SOME_OPTIONS" | scl enable rh-ruby23 -
-   ```
-   * or create a wrapper script:
-   ```bash
-   #!/usr/bin/env sh
-   
-   source scl_source enable rh-ruby23
-   /path/to/test_pull_requests "$@"
-   ```
+   * Enable the Software Collections (SCL) repos and install `scl-utils`, and the Ruby version of your choice, e.g. `rh-ruby23`, `rh-ruby23-rubygems`, and `rh-ruby23-rubygem-bundler`
+     * Install the dependencies: `cd test-pull-requests ; echo "bundle install" | scl enable rh-ruby23 -`
+   * If you have more than one SCL Ruby installed, edit `test_pull_requests_ruby_wrapper.sh` so it only detects the desired Ruby version.
 
 ### Setup for merge_queue_overview
  * Add `merge_queue_overview` to your Jenkins system and make sure it's executable

--- a/test_pull_requests
+++ b/test_pull_requests
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env test_pull_requests_ruby_wrapper.sh
 
 # Client script for submitting pull requests for testing
 # as well as updating the test results from Jenkins.

--- a/test_pull_requests_ruby_wrapper.sh
+++ b/test_pull_requests_ruby_wrapper.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+pick_scl_ruby() {
+    # select the first suitable installed ruby scl version. Edit this
+    # to be more specific if needed.
+    scl --list | grep 'rh-ruby2[234]' | head -n1
+}
+
+SCL_RUBY=""
+if ruby --version | grep --extended-regexp --quiet '^ruby +2\.0\.0'
+then
+  SCL_RUBY="$(pick_scl_ruby)"
+fi
+
+# If we can't find a newer ruby then just try the old one anyway.
+if [[ -n "${SCL_RUBY}" ]]
+then
+  source scl_source enable "${SCL_RUBY}"
+fi
+
+# ruby --version
+exec ruby "$@"


### PR DESCRIPTION
Add `test_pull_requests_ruby_wrapper.sh` and modify the shebang line in
`test_pull_requests` to run it. This wrapper attempts to detect a
suitable SCL Ruby installation for running the script.

Also update the README accordingly