### PR TITLE
Remove logic to skip old PRs, fix auto_paginate

### DIFF
--- a/test_pull_requests
+++ b/test_pull_requests
@@ -202,6 +202,8 @@ MERGEABLE = 0
 # Base sleep time for API retries
 SLEEP_TIME = 1
 
+Octokit::auto_paginate = true
+
 def evaluated_marker(repo, settings)
   "Evaluated for #{Properties['repo_to_product'][repo].downcase} #{settings['name']} up to %s"
 end
@@ -607,7 +609,6 @@ class CIClient < Octokit::Client
     Octokit::middleware = cache_stack
     super(:access_token => hubcfg['github.com'].first['oauth_token'])
     configure { |c| c.per_page = 100 }
-    Octokit::auto_paginate = true
     @dry_run_msg = @dry_run ? "Dry run; skipping: " : ""
   end
 
@@ -2029,66 +2030,57 @@ popd
         if $branches.include?(branch) || $branches.include?('*')
 
           $stderr.puts "  Updated at: #{req['updated_at']}"
-          # We only want to consider pull requests that have been modified in
-          # the last twelve hours, to stop us from doing extra work when we
-          # don't need to. Also, just to ensure that we don't forget a pull
-          # request forever on accident, there is a 10% chance we'll consider
-          # a pull request even if it is inactive
-          if Time.now - req['updated_at'] < (12*60*60) || (rand(20) < 1)
-            login = req['user']['login']
-            comments = nil
-            # Skip if it's not mergeable
-            mergeable = is_mergeable?(id, repo)
-            $stderr.puts "  Mergeable: #{mergeable}"
-            if mergeable
-              comments = issue_comments("#{@properties['github_user']}/#{repo}", id) if comments.nil?
-              set_mergeable(id, repo, login, comments)
-            else
-              if set_not_mergeable(id, repo, login) == MERGEABLE
-                mergeability_in_flux = true
-              end
-              next
-            end
+          login = req['user']['login']
+          comments = nil
+          # Skip if it's not mergeable
+          mergeable = is_mergeable?(id, repo)
+          $stderr.puts "  Mergeable: #{mergeable}"
+          if mergeable
             comments = issue_comments("#{@properties['github_user']}/#{repo}", id) if comments.nil?
+            set_mergeable(id, repo, login, comments)
+          else
+            if set_not_mergeable(id, repo, login) == MERGEABLE
+              mergeability_in_flux = true
+            end
+            next
+          end
+          comments = issue_comments("#{@properties['github_user']}/#{repo}", id) if comments.nil?
 
-            # We only want to consider pull requests where the last trigger we found
-            # is from a trusted user
-            permission_denied = Array.new(@properties['settings'].length, false)
-            # Has a merge or test been requested by a trusted user?
-            @properties['settings'].values.each_with_index do |settings, i|
-              updated_at, changed_after_eval = get_updated_at(req, comments, settings)
-              trigger_regex = /\[#{settings['name']}\]/i
-              if req['title'] =~ trigger_regex || req['body'] =~ trigger_regex
-                if user_trusted?(login, repo, settings)
+          # We only want to consider pull requests where the last trigger we found
+          # is from a trusted user
+          permission_denied = Array.new(@properties['settings'].length, false)
+          # Has a merge or test been requested by a trusted user?
+          @properties['settings'].values.each_with_index do |settings, i|
+            updated_at, changed_after_eval = get_updated_at(req, comments, settings)
+            trigger_regex = /\[#{settings['name']}\]/i
+            if req['title'] =~ trigger_regex || req['body'] =~ trigger_regex
+              if user_trusted?(login, repo, settings)
+                pull_requests << [req, updated_at, changed_after_eval, comments, settings]
+                permission_denied[i] = false
+                next
+              else
+                $stderr.puts "  User '#{login}' not trusted"
+                permission_denied[i] = true
+              end
+            end
+
+            comments = sort_comments(comments)
+            comments.each do |comment|
+              if comment['body'] =~ trigger_regex
+                comment_login = comment['user']['login']
+                if user_trusted?(comment_login, repo, settings)
                   pull_requests << [req, updated_at, changed_after_eval, comments, settings]
                   permission_denied[i] = false
-                  next
+                  break
                 else
-                  $stderr.puts "  User '#{login}' not trusted"
+                  $stderr.puts "  User '#{comment_login}' not trusted"
                   permission_denied[i] = true
                 end
               end
-
-              comments = sort_comments(comments)
-              comments.each do |comment|
-                if comment['body'] =~ trigger_regex
-                  comment_login = comment['user']['login']
-                  if user_trusted?(comment_login, repo, settings)
-                    pull_requests << [req, updated_at, changed_after_eval, comments, settings]
-                    permission_denied[i] = false
-                    break
-                  else
-                    $stderr.puts "  User '#{comment_login}' not trusted"
-                    permission_denied[i] = true
-                  end
-                end
-              end
             end
-            if permission_denied.include? true
-              create_or_update_comment(id, repo, ACTION_PREFIX, ACTION_NOT_TEAM, comments)
-            end
-          else
-            $stderr.puts "  Skipping due to age and inactivity"
+          end
+          if permission_denied.include? true
+            create_or_update_comment(id, repo, ACTION_PREFIX, ACTION_NOT_TEAM, comments)
           end
         else
           create_or_update_comment(id, repo, ACTION_PREFIX, ACTION_UNSUPPORTED_BRANCH)


### PR DESCRIPTION
We have caching, so there's no reason to skip old PRs

`OctoKit::auto_paginate` wasn't being enabled properly, so we were
only getting the first 100 of anything.